### PR TITLE
force brackets in Style/WordArray in .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,10 @@
 Metrics/LineLength:
   Max: 120
 
+Style/WordArray:
+  Description: 'Use %w or %W for arrays of words.'
+  EnforcedStyle: brackets
+
 Style/Documentation:
   Enabled: false
 


### PR DESCRIPTION
no more %w(terrorism)